### PR TITLE
Add ContinuousMove and Stop PTZ operations

### DIFF
--- a/lib/ptz.ex
+++ b/lib/ptz.ex
@@ -10,7 +10,7 @@ defmodule ExOnvif.PTZ do
   import ExOnvif.Utils.Parser
   import SweetXml
 
-  alias ExOnvif.PTZ.{AbsoluteMove, Node, ServiceCapabilities, Status}
+  alias ExOnvif.PTZ.{AbsoluteMove, ContinuousMove, Node, ServiceCapabilities, Status, Stop}
 
   @doc """
   Operation to move pan,tilt or zoom to a absolute destination.
@@ -23,6 +23,29 @@ defmodule ExOnvif.PTZ do
   def absolute_move(device, abs_move) do
     body = AbsoluteMove.encode(abs_move)
     ptz_request(device, "AbsoluteMove", body, fn _body -> :ok end)
+  end
+
+  @doc """
+  Operation for continuous Pan/Tilt and Zoom movements.
+
+  The operation is supported if the PTZNode supports at least one continuous Pan/Tilt or Zoom space.
+  If the space argument is omitted, the default space set by the PTZConfiguration will be used.
+  """
+  @spec continuous_move(ExOnvif.Device.t(), ContinuousMove.t()) :: :ok | {:error, any()}
+  def continuous_move(device, continuous_move) do
+    body = ContinuousMove.encode(continuous_move)
+    ptz_request(device, "ContinuousMove", body, fn _body -> :ok end)
+  end
+
+  @doc """
+  Operation to stop ongoing pan, tilt and zoom movements of absolute, relative and continuous type.
+
+  If no stop argument for pan, tilt or zoom is set, the device will stop all ongoing pan, tilt and zoom movements.
+  """
+  @spec stop(ExOnvif.Device.t(), Stop.t()) :: :ok | {:error, any()}
+  def stop(device, stop) do
+    body = Stop.encode(stop)
+    ptz_request(device, "Stop", body, fn _body -> :ok end)
   end
 
   @doc """

--- a/lib/ptz/absolute_move.ex
+++ b/lib/ptz/absolute_move.ex
@@ -40,12 +40,22 @@ defmodule ExOnvif.PTZ.AbsoluteMove do
   end
 
   def encode(%__MODULE__{} = absolute_move) do
-    element(
-      "tptz:AbsoluteMove",
-      element("tptz:ProfileToken", absolute_move.profile_token)
-      |> element("tptz:Position", Vector.encode(absolute_move.position))
-      |> element("tptz:Speed", Vector.encode(absolute_move.speed))
-    )
+    # Build in reverse order since element() prepends to list
+    # We want: ProfileToken, Position, Speed
+    # So build: Speed, Position, ProfileToken
+    base =
+      if absolute_move.speed do
+        element("tptz:Speed", Vector.encode(absolute_move.speed))
+      else
+        []
+      end
+
+    base =
+      base
+      |> element("tptz:Position", nil, Vector.encode(absolute_move.position))
+      |> element("tptz:ProfileToken", nil, absolute_move.profile_token)
+
+    element("tptz:AbsoluteMove", base)
   end
 
   def changeset(absolute_move, attrs) do

--- a/lib/ptz/continuous_move.ex
+++ b/lib/ptz/continuous_move.ex
@@ -1,0 +1,55 @@
+defmodule ExOnvif.PTZ.ContinuousMove do
+  @moduledoc """
+  Schema describing the continuous move request to the PTZ service.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import ExOnvif.Utils.XmlBuilder
+
+  alias ExOnvif.PTZ.Vector
+
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  @derive Jason.Encoder
+  embedded_schema do
+    field :profile_token, :string
+    embeds_one :velocity, Vector
+  end
+
+  @doc """
+  Creates a new continuous move request.
+
+  ## Parameters
+    - `profile_token` - The token of the profile to move.
+    - `velocity` - The velocity to move at, represented as a `Vector`.
+  """
+  @spec new(String.t(), Vector.t()) :: t()
+  def new(profile_token, velocity) do
+    %__MODULE__{
+      profile_token: profile_token,
+      velocity: velocity
+    }
+  end
+
+  def encode(%__MODULE__{} = continuous_move) do
+    # Build in reverse order since element() prepends to list
+    # We want: ProfileToken, Velocity
+    # So build: Velocity, ProfileToken
+    base =
+      []
+      |> element("tptz:Velocity", nil, Vector.encode(continuous_move.velocity))
+      |> element("tptz:ProfileToken", nil, continuous_move.profile_token)
+
+    element("tptz:ContinuousMove", base)
+  end
+
+  def changeset(continuous_move, attrs) do
+    continuous_move
+    |> cast(attrs, [:profile_token])
+    |> cast_embed(:velocity)
+    |> validate_required([:profile_token])
+  end
+end

--- a/lib/ptz/continuous_move.ex
+++ b/lib/ptz/continuous_move.ex
@@ -35,9 +35,6 @@ defmodule ExOnvif.PTZ.ContinuousMove do
   end
 
   def encode(%__MODULE__{} = continuous_move) do
-    # Build in reverse order since element() prepends to list
-    # We want: ProfileToken, Velocity
-    # So build: Velocity, ProfileToken
     base =
       []
       |> element("tptz:Velocity", nil, Vector.encode(continuous_move.velocity))

--- a/lib/ptz/stop.ex
+++ b/lib/ptz/stop.ex
@@ -27,6 +27,8 @@ defmodule ExOnvif.PTZ.Stop do
     - `zoom` - Whether to stop zoom movement (default: true).
   """
   @spec new(String.t(), boolean(), boolean()) :: t()
+  @spec new(String.t(), boolean()) :: t()
+  @spec new(String.t()) :: t()
   def new(profile_token, pan_tilt \\ true, zoom \\ true) do
     %__MODULE__{
       profile_token: profile_token,

--- a/lib/ptz/stop.ex
+++ b/lib/ptz/stop.ex
@@ -36,9 +36,6 @@ defmodule ExOnvif.PTZ.Stop do
   end
 
   def encode(%__MODULE__{} = stop) do
-    # Build in reverse order since element() prepends to list
-    # We want: ProfileToken, PanTilt, Zoom
-    # So build: Zoom, PanTilt, ProfileToken
     base =
       []
       |> element("tptz:Zoom", nil, to_string(stop.zoom))

--- a/lib/ptz/stop.ex
+++ b/lib/ptz/stop.ex
@@ -1,0 +1,56 @@
+defmodule ExOnvif.PTZ.Stop do
+  @moduledoc """
+  Schema describing the stop request to the PTZ service.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import ExOnvif.Utils.XmlBuilder
+
+  @type t :: %__MODULE__{}
+
+  @primary_key false
+  @derive Jason.Encoder
+  embedded_schema do
+    field :profile_token, :string
+    field :pan_tilt, :boolean
+    field :zoom, :boolean
+  end
+
+  @doc """
+  Creates a new stop request.
+
+  ## Parameters
+    - `profile_token` - The token of the profile to stop.
+    - `pan_tilt` - Whether to stop pan/tilt movement (default: true).
+    - `zoom` - Whether to stop zoom movement (default: true).
+  """
+  @spec new(String.t(), boolean(), boolean()) :: t()
+  def new(profile_token, pan_tilt \\ true, zoom \\ true) do
+    %__MODULE__{
+      profile_token: profile_token,
+      pan_tilt: pan_tilt,
+      zoom: zoom
+    }
+  end
+
+  def encode(%__MODULE__{} = stop) do
+    # Build in reverse order since element() prepends to list
+    # We want: ProfileToken, PanTilt, Zoom
+    # So build: Zoom, PanTilt, ProfileToken
+    base =
+      []
+      |> element("tptz:Zoom", nil, to_string(stop.zoom))
+      |> element("tptz:PanTilt", nil, to_string(stop.pan_tilt))
+      |> element("tptz:ProfileToken", nil, stop.profile_token)
+
+    element("tptz:Stop", base)
+  end
+
+  def changeset(stop, attrs) do
+    stop
+    |> cast(attrs, [:profile_token, :pan_tilt, :zoom])
+    |> validate_required([:profile_token])
+  end
+end

--- a/lib/utils/api_client.ex
+++ b/lib/utils/api_client.ex
@@ -187,18 +187,10 @@ defmodule ExOnvif.Utils.ApiClient do
   end
 
   defp do_request(device, service_path, namespaces, action, content, parser_fn) do
-    require Logger
-
     request_body = %ExOnvif.Request{
       content: XmlBuilder.element(:"s:Body", List.wrap(content)),
       namespaces: namespaces
     }
-
-    # Log full SOAP envelope for PTZ debugging
-    if String.contains?(action, "/ptz/") do
-      encoded_xml = ExOnvif.Request.encode(request_body)
-      Logger.warning("PTZ SOAP Envelope being sent:\n#{encoded_xml}")
-    end
 
     device
     |> ExOnvif.API.client(service_path: service_path)


### PR DESCRIPTION
Adds ContinuousMove and Stop PTZ commands. Needed these for Sony cameras with digital PTZ (SolidPTZ) - they don't respond to AbsoluteMove at all, only ContinuousMove.

Also fixed element ordering in AbsoluteMove - some cameras are strict about the order (ProfileToken, Position, Speed).

Added zoom_space to Vector so you can set coordinate spaces properly.

Tested with Axis (mechanical PTZ) and Sony SNC-EM631 (digital PTZ). Both work now.

Changes:
- New: lib/ptz/continuous_move.ex
- New: lib/ptz/stop.ex  
- Modified: lib/ptz.ex (added continuous_move/2 and stop/2)
- Modified: lib/ptz/vector.ex (added zoom_space field)
- Modified: lib/ptz/absolute_move.ex (fixed element order)

No breaking changes, just new functions.